### PR TITLE
feat: Add Login Screen and Logic

### DIFF
--- a/app/src/main/kotlin/com/safehelmet/safehelmet_mobile/MainActivity.kt
+++ b/app/src/main/kotlin/com/safehelmet/safehelmet_mobile/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.safehelmet.safehelmet_mobile
 
+import LoginScreen
 import android.os.Bundle
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -25,15 +27,18 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.lifecycleScope
 import com.safehelmet.safehelmet_mobile.api.HttpClient
 import com.safehelmet.safehelmet_mobile.ble.BleDevice
 import com.safehelmet.safehelmet_mobile.ble.BleManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import login
 
 
 class MainActivity : ComponentActivity() {
+    var isLogin = mutableStateOf(false)
     private lateinit var bleManager: BleManager
 
     private val enableBluetoothLauncher =
@@ -65,11 +70,31 @@ class MainActivity : ComponentActivity() {
         bleManager.initializeBluetooth()
 
         setContent {
-            BluetoothScreenWrapper(bleManager)
+            if (!isLogin.value) {
+                LoginScreen { username, password ->
+                    lifecycleScope.launch {
+                        val loginSuccessful = login(username, password)
+
+                        if (loginSuccessful) {
+                            isLogin.value = true
+                        }else{
+                            Toast.makeText(this@MainActivity, "Not a valid login", Toast.LENGTH_LONG).show()
+                        }
+                    }
+                }
+            } else {
+                BluetoothScreenWrapper(bleManager)
+            }
         }
     }
 
+
+
+
+
 }
+
+
 
 
 enum class ConnectionState {

--- a/app/src/main/kotlin/com/safehelmet/safehelmet_mobile/ui/Login.kt
+++ b/app/src/main/kotlin/com/safehelmet/safehelmet_mobile/ui/Login.kt
@@ -1,0 +1,87 @@
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.safehelmet.safehelmet_mobile.api.HttpClient
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+@Composable
+fun LoginScreen(onLogin: (String, String) -> Unit) {
+    var username by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp), verticalArrangement = Arrangement.Center
+    ) {
+        TextField(
+            value = username,
+            onValueChange = { username = it },
+            label = { Text("Username") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        TextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Password") },
+            visualTransformation = PasswordVisualTransformation(),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = {
+                onLogin(username, password)
+            }, modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Login")
+        }
+    }
+}
+
+// Funzione di login asincrona
+suspend fun login(username: String, password: String): Boolean {
+    return suspendCancellableCoroutine { continuation ->
+        Log.i("Login", "Start Login Request")
+
+        // Esegui la richiesta HTTP in modo asincrono
+        HttpClient.postRequest(
+            "/api/v1/login", "username=$username&password=$password"
+        ) { response ->
+            Log.i("Login", "Response received: ${response?.isSuccessful}")
+
+            if (response?.isSuccessful == true) {
+                // Se la risposta è positiva, prosegui e restituisci true
+                continuation.resume(true)
+            } else {
+                // In caso di errore, restituisci false
+                continuation.resume(false)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a new login screen with username and password fields, along with an asynchronous login function. The app now displays the login screen on startup and, upon successful login, transitions to the Bluetooth device list view. Also implemented logic to handle login success or failure.